### PR TITLE
Fixed import problem of scipy.misc.comb

### DIFF
--- a/ecopy/diversity/rarefy.py
+++ b/ecopy/diversity/rarefy.py
@@ -1,6 +1,6 @@
 import numpy as np
 from pandas import DataFrame
-from scipy.misc import comb
+from scipy.special import comb
 import matplotlib.pyplot as plt
 
 def rarefy(x, method='rarefy', size = None, breakNA=True):


### PR DESCRIPTION
Importing comb from scipy.misc is deprecated in scipy 1.0.0.